### PR TITLE
SES-5851: Include missing cstdint header

### DIFF
--- a/include/rosout_print/process_rosout.h
+++ b/include/rosout_print/process_rosout.h
@@ -30,6 +30,7 @@
 #ifndef ROSOUT_PRINT_PROCESS_ROSOUT_H
 #define ROSOUT_PRINT_PROCESS_ROSOUT_H
 
+#include <cstdint>
 #include <map>
 #include <string>
 


### PR DESCRIPTION
Corrects this build failure that happens with GCC 13:

```
[ 66%] Building CXX object CMakeFiles/rosout_print.dir/src/process_rosout.cpp.o
[ 66%] Building CXX object CMakeFiles/rosout_print.dir/src/rosout_print.cpp.o
In file included from /build/source/src/process_rosout.cpp:30:
/build/source/include/rosout_print/process_rosout.h:54:36: error: ‘uint8_t’ does not name a type
   54 |                              const uint8_t,
      |                                    ^~~~~~~
/build/source/include/rosout_print/process_rosout.h:35:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   34 | #include <string>
  +++ |+#include <cstdint>
   35 | 
/build/source/include/rosout_print/process_rosout.h:63:37: error: ‘uint8_t’ does not name a type
   63 | int processRosoutAggMsgsInBag(const uint8_t,
      |                                     ^~~~~~~
/build/source/include/rosout_print/process_rosout.h:63:37: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
make[2]: *** [CMakeFiles/rosout_print.dir/build.make:90: CMakeFiles/rosout_print.dir/src/process_rosout.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:603: CMakeFiles/rosout_print.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

http://hydra.clearpath.ai/build/1034763/nixlog/46