### PR TITLE
Switch to clang-format-18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,49 +1,67 @@
+# cpr-autonomy-clang-format: 0.2
 ---
-# CatkinClangFormatVersionToUse: 10
-BasedOnStyle:  Google
 AccessModifierOffset: -4
-ConstructorInitializerIndentWidth: 2
 AlignEscapedNewlinesLeft: false
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakTemplateDeclarations: true
 AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BasedOnStyle:  Google
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
 BreakBeforeBinaryOperators: false
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: true
-BinPackParameters: false
 ColumnLimit:    90
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
 DerivePointerBinding: true
 ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: Preserve
 IndentCaseLabels: false
+IndentFunctionDeclarationAfterType: false
+IndentWidth:     4
+InsertNewlineAtEOF: true
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 60
-PenaltyBreakString: 1
 PenaltyBreakFirstLessLess: 1000
-PenaltyExcessCharacter: 100
+PenaltyBreakString: 1
+PenaltyExcessCharacter: 1000
 PenaltyReturnTypeOnItsOwnLine: 90
-PointerBindsToType: false
-SpacesBeforeTrailingComments: 2
-Cpp11BracedListStyle: false
-Standard:        Cpp03
-IndentWidth:     4
-TabWidth:        4
-UseTab:          Never
-BreakBeforeBraces: Allman
-IndentFunctionDeclarationAfterType: false
-SpacesInParentheses: false
-SpacesInAngles:  false
-SpaceInEmptyParentheses: false
-SpacesInCStyleCastParentheses: false
+PointerAlignment: Right
 SpaceAfterControlStatementKeyword: true
 SpaceBeforeAssignmentOperators: true
-ContinuationIndentWidth: 4
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+Standard:        Auto
+TabWidth:        4
+UseTab:          Never
 ...

--- a/package.xml
+++ b/package.xml
@@ -17,4 +17,5 @@
   <depend>rosgraph_msgs</depend>
 
   <test_depend>catkin_clang_format</test_depend>
+  <test_depend>clang-format-18</test_depend>
 </package>


### PR DESCRIPTION
Updates the `clang-format` version from 10 to 18. The `.clang-format` config file is also updated in such a way to remove deprecated options while not requiring any code changes.